### PR TITLE
Add postal code auto-fill to signup form

### DIFF
--- a/src/Signup.css
+++ b/src/Signup.css
@@ -24,3 +24,16 @@
   background-color: #fff;
   color: #000;
 }
+
+.zipcode-field {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.zipcode-field input {
+  flex: 1;
+}
+
+.zipcode-field button {
+  padding: 0.5rem;
+}

--- a/src/Signup.tsx
+++ b/src/Signup.tsx
@@ -4,12 +4,21 @@ import './Signup.css'
 interface FormState {
   name: string
   email: string
+  postalCode: string
+  address: string
   password: string
   confirm: string
 }
 
 function Signup() {
-  const [form, setForm] = useState<FormState>({ name: '', email: '', password: '', confirm: '' })
+  const [form, setForm] = useState<FormState>({
+    name: '',
+    email: '',
+    postalCode: '',
+    address: '',
+    password: '',
+    confirm: '',
+  })
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target
@@ -20,6 +29,25 @@ function Signup() {
     e.preventDefault()
     // Placeholder for submission logic
     console.log('User registered:', form)
+  }
+
+  const handleZipSearch = async () => {
+    if (!form.postalCode) return
+    try {
+      const res = await fetch(
+        `https://zipcloud.ibsnet.co.jp/api/search?zipcode=${form.postalCode}`
+      )
+      const data = await res.json()
+      if (data.results && data.results[0]) {
+        const result = data.results[0]
+        const fullAddress = `${result.address1}${result.address2}${result.address3}`
+        setForm((prev) => ({ ...prev, address: fullAddress }))
+      } else {
+        alert('住所が見つかりませんでした')
+      }
+    } catch (error) {
+      console.error('Error fetching address:', error)
+    }
   }
 
   return (
@@ -33,6 +61,31 @@ function Signup() {
         <label>
           メールアドレス
           <input type="email" name="email" value={form.email} onChange={handleChange} required />
+        </label>
+        <label>
+          郵便番号
+          <div className="zipcode-field">
+            <input
+              type="text"
+              name="postalCode"
+              value={form.postalCode}
+              onChange={handleChange}
+              required
+            />
+            <button type="button" onClick={handleZipSearch}>
+              住所検索
+            </button>
+          </div>
+        </label>
+        <label>
+          住所
+          <input
+            type="text"
+            name="address"
+            value={form.address}
+            onChange={handleChange}
+            required
+          />
         </label>
         <label>
           パスワード


### PR DESCRIPTION
## Summary
- extend signup form with postal code and address fields
- fetch address from zip code and auto-fill the form
- style postal code field and search button

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bff421e8cc83339bd6bc9b51ef67c9